### PR TITLE
Added example for using proxy fields on FormController create

### DIFF
--- a/controllers/People.php
+++ b/controllers/People.php
@@ -2,6 +2,7 @@
 
 use BackendMenu;
 use Backend\Classes\Controller;
+use October\Test\Models\Phone;
 
 /**
  * People Back-end Controller
@@ -23,5 +24,15 @@ class People extends Controller
         parent::__construct();
 
         BackendMenu::setContext('October.Test', 'test', 'people');
+    }
+
+    public function formExtendModel($model)
+    {
+        //init proxy field model if we are creating and the context is proxyfields.
+        if ($this->action == 'create' && $this->asExtension('FormController')->formGetContext() == 'proxyfields') {
+            $model->phone = new Phone();
+        }
+
+        return $model;
     }
 }

--- a/controllers/people/_form_toggle.htm
+++ b/controllers/people/_form_toggle.htm
@@ -12,15 +12,7 @@
         <ul>
             <li><a href="<?= Backend::url($uriPrefix.'/recordfinder') ?>">Record Finder</a></li>
             <li><a href="<?= Backend::url($uriPrefix.'/relationcontroller') ?>">Relation Controller</a></li>
-            <li>
-                <?php if ($formModel->phone): ?>
-                    <a href="<?= Backend::url($uriPrefix.'/proxyfields') ?>">
-                        Proxy Fields
-                    </a>
-                <?php else: ?>
-                    Proxy Fields (<em>No phone relation found</em>)
-                <?php endif ?>
-            </li>
+            <li><a href="<?= Backend::url($uriPrefix.'/proxyfields') ?>">Proxy Fields</a></li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
By manually instantiating the Person->phone relation we gain the ability to use proxy fields on create. (Yes, it saves too)
I had a use case where I needed this for another project and decided that since proxy fields are really only documented here that this is where this example belongs.
