### PR TITLE
Create scenario where a hasMany relationship throws constraint errors when storing child records

### DIFF
--- a/controllers/people/_notes.htm
+++ b/controllers/people/_notes.htm
@@ -1,0 +1,1 @@
+<?= $this->relationRender('notes') ?>

--- a/controllers/people/config_relation.yaml
+++ b/controllers/people/config_relation.yaml
@@ -6,3 +6,11 @@ phone:
     label: Phone
     form: ~/plugins/october/test/models/phone/fields.yaml
     list: ~/plugins/october/test/models/phone/columns.yaml
+
+notes:
+    label: Notes
+    view:
+        list: $/october/test/models/note/columns.yaml
+        toolbarButtons: create|delete
+    manage:
+        form: $/october/test/models/note/fields.yaml

--- a/controllers/people/index.htm
+++ b/controllers/people/index.htm
@@ -9,4 +9,12 @@
             <p>One to one relationship</p>
         </div>
     </div>
+
+    <div class="callout callout-warning">
+        <div class="header">
+            <i class="icon-database"></i>
+            <h3>A Person "Has Many" Notes</h3>
+            <p>One to many relationship</p>
+        </div>
+    </div>
 </div>

--- a/models/Note.php
+++ b/models/Note.php
@@ -1,0 +1,33 @@
+<?php namespace October\Test\Models;
+
+use Model;
+
+/**
+ * Note Model
+ */
+class Note extends Model
+{
+
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'october_test_notes';
+
+    /**
+     * @var array Guarded fields
+     */
+    protected $guarded = ['*'];
+
+    /**
+     * @var array Fillable fields
+     */
+    protected $fillable = [];
+
+    /**
+     * @var array Relations
+     */
+    public $belongsTo = [
+        'person' => ['October\Test\Models\Person']
+    ];
+
+}

--- a/models/Person.php
+++ b/models/Person.php
@@ -40,4 +40,8 @@ class Person extends Model
         'alt_phone' => ['October\Test\Models\Phone', 'key' => 'person_id']
     ];
 
+    public $hasMany = [
+        'notes' => ['October\Test\Models\Note', 'key' => 'person_id'],
+    ];
+
 }

--- a/models/note/columns.yaml
+++ b/models/note/columns.yaml
@@ -1,0 +1,12 @@
+# ===================================
+#  List Column Definitions
+# ===================================
+
+columns:
+    title:
+        label: Title
+        searchable: true
+
+    id:
+        label: ID
+        searchable: true

--- a/models/note/fields.yaml
+++ b/models/note/fields.yaml
@@ -1,0 +1,15 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+    title:
+        label: Title
+
+    body:
+        label: Body
+        type: textarea
+
+    id:
+        label: ID
+        disabled: true

--- a/models/person/fields.yaml
+++ b/models/person/fields.yaml
@@ -3,7 +3,7 @@
 # ===================================
 #
 #  These fields explore the use of context; the "phone" field is rendered in
-#  different ways depending on the context used by the form, passed in by 
+#  different ways depending on the context used by the form, passed in by
 #  the URL.
 # ===================================
 
@@ -97,3 +97,8 @@ tabs:
             default: "#27ae60"
             tab: Birthday
             span: auto
+
+        notes:
+            label: Notes
+            type: partial
+            tab: Notes

--- a/updates/create_notes_table.php
+++ b/updates/create_notes_table.php
@@ -1,0 +1,29 @@
+<?php namespace October\Test\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class CreateNotesTable extends Migration
+{
+
+    public function up()
+    {
+        Schema::create('october_test_notes', function($table)
+        {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->string('title')->nullable();
+            $table->text('body')->nullable();
+            $table->unsignedInteger('person_id')->index();
+            $table->timestamps();
+
+            $table->foreign('person_id')->references('id')->on('october_test_people')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('october_test_notes');
+    }
+
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -5,3 +5,6 @@
 1.0.3:
   - Seed tables
   - seed_tables.php
+1.0.4:
+  - Add notes
+  - create_notes_table.php


### PR DESCRIPTION
So I put together a scenario where you might want to attach `Notes` to a `Person`. Notes is a tab within a  Persons controller.

This is a different `hasMany` implementation than what `Posts` and `Comments` have because in that scenario, selecting the post that the comment belongsTo is part of the comment form, so it has the parent id as part of the request. However, in some cases the child should be assumed it belongsTo the parent and it doesn't necessarily make sense to be required to select the parent.

Let me know if that makes sense. This will require a migration since I added a `Notes` model.
