### PR TITLE
octobercms issue1827 demo: disable post editing in comment model

### DIFF
--- a/models/comment/fields.yaml
+++ b/models/comment/fields.yaml
@@ -10,7 +10,14 @@ fields:
         nameFrom: name
         emptyOption: -- Select Post --
         comment: This Comment belongs to the Post selected above.
-        context: ['create', 'update']
+        context: ['create']
+
+    post@update:
+        type: relation
+        nameFrom: name
+        emptyOption: -- Select Post --
+        comment: This Comment belongs to the Post selected above.
+        disabled: true
 
     name:
         label: Name


### PR DESCRIPTION
Assume that we want to set related post when creating comment and disable post selection when updating.
Just try to create comment with post and update it then. Open comment editing window after update and you'll see that relation was reset.
