### PR TITLE
Added users filtering by role to demonstrate issue 1918

### DIFF
--- a/controllers/users/config_filter.yaml
+++ b/controllers/users/config_filter.yaml
@@ -1,0 +1,12 @@
+# ===================================
+# Filter Scope Definitions
+# ===================================
+
+scopes:
+
+    roles:
+        label: Role
+        scope: ApplyRoleFilter
+        modelClass: October\Test\Models\Role
+        nameFrom: name
+        conditions: role_id in (:filtered)

--- a/controllers/users/config_list.yaml
+++ b/controllers/users/config_list.yaml
@@ -42,3 +42,6 @@ toolbar:
     # Search widget configuration
     search:
         prompt: backend::lang.list.search_prompt
+
+# Displays the list filter        
+filter: config_filter.yaml

--- a/models/User.php
+++ b/models/User.php
@@ -77,6 +77,9 @@ class User extends Model
         'files' => ['System\Models\File'],
         'files_secure' => ['System\Models\File', 'public' => false],
     ];
-
+    
+    public function scopeApplyRoleFilter($query) {
+        return $query->join('october_test_users_roles', 'october_test_users.id', '=', 'october_test_users_roles.user_id');
+    }
 
 }


### PR DESCRIPTION
Demonstrates [issue 1918](https://github.com/octobercms/october/issues/1918#issue-146776558)

Steps to replicate using test plugin:
1. Go to Users list and choose two options in Role filter: "Chief Friendship Organiser" and "Chief Executive Orangutan"
2. Click anywhere so filters dropdown closes and users list refreshes.
3. Open same filter again and in filter dropdown's Search field type: "Officer"

Current behavior: Search fails to find "Caring Technical Officer" filter option.
Expected behavior: "Caring Technical Officer" option should be found and available to select.
