### PR TITLE
Added basic example of attached HTML reusing the attachOne relationship

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -64,6 +64,11 @@ class Plugin extends PluginBase
                         'icon'        => 'icon-database',
                         'url'         => Backend::url('october/test/trees'),
                     ],
+                    'venues' => [
+                        'label'       => 'Venues',
+                        'url'         => Backend::url('october/test/venues'),
+                        'icon'        => 'icon-building',
+                    ]
                 ]
             ]
         ];

--- a/controllers/Venues.php
+++ b/controllers/Venues.php
@@ -1,0 +1,25 @@
+<?php namespace October\Test\Controllers;
+
+use BackendMenu;
+use Backend\Classes\Controller;
+
+/**
+ * Users Back-end Controller
+ */
+class Venues extends Controller
+{
+    public $implement = [
+        'Backend.Behaviors.FormController',
+        'Backend.Behaviors.ListController',
+    ];
+
+    public $formConfig = 'config_form.yaml';
+    public $listConfig = 'config_list.yaml';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        BackendMenu::setContext('October.Test', 'test', 'venues');
+    }
+}

--- a/controllers/venues/_list_toolbar.htm
+++ b/controllers/venues/_list_toolbar.htm
@@ -1,0 +1,3 @@
+<div data-control="toolbar">
+    <a href="<?= Backend::url('october/test/venues/create') ?>" class="btn btn-primary oc-icon-plus">New Venue</a>
+</div>

--- a/controllers/venues/config_form.yaml
+++ b/controllers/venues/config_form.yaml
@@ -1,0 +1,14 @@
+name: Venue
+form: $/october/test/models/venue/fields.yaml
+modelClass: October\Test\Models\Venue
+defaultRedirect: october/test/venues
+
+create:
+    title: New Venue
+    redirect: october/test/venues
+    redirectClose: october/test/venues
+
+update:
+    title: Edit Venue
+    redirect: october/test/venues
+    redirectClose: october/test/venues

--- a/controllers/venues/config_list.yaml
+++ b/controllers/venues/config_list.yaml
@@ -1,0 +1,6 @@
+title: Blog Posts
+list: $/october/test/models/venue/columns.yaml
+modelClass: October\Test\Models\Venue
+recordUrl: october/test/venues/update/:id
+toolbar:
+    buttons: list_toolbar

--- a/controllers/venues/create.htm
+++ b/controllers/venues/create.htm
@@ -1,0 +1,24 @@
+<?= Form::open(['class'=>'layout']) ?>
+
+<div class="layout-row">
+    <?= $this->formRender() ?>
+</div>
+
+<div class="form-buttons">
+    <div class="loading-indicator-container">
+        <button
+                type="button"
+                data-request="onSave"
+                data-request-data="close:true"
+                data-hotkey="ctrl+enter, cmd+enter"
+                data-load-indicator="Creating Venue..."
+                class="btn btn-default">
+            Create and Close
+        </button>
+        <span class="btn-text">
+                or <a href="<?= Backend::url('october/test/venues') ?>">Cancel</a>
+            </span>
+    </div>
+</div>
+
+<?= Form::close() ?>

--- a/controllers/venues/index.htm
+++ b/controllers/venues/index.htm
@@ -1,0 +1,1 @@
+<?= $this->listRender() ?>

--- a/controllers/venues/update.htm
+++ b/controllers/venues/update.htm
@@ -1,0 +1,31 @@
+<?= Form::open(['class'=>'layout']) ?>
+
+<div class="layout-row">
+    <?= $this->formRender() ?>
+</div>
+
+<div class="form-buttons">
+    <div class="loading-indicator-container">
+        <button
+                type="button"
+                data-request="onSave"
+                data-request-data="close:true"
+                data-hotkey="ctrl+enter, cmd+enter"
+                data-load-indicator="Saving Venue..."
+                class="btn btn-default">
+            Save and Close
+        </button>
+        <button
+                type="button"
+                class="oc-icon-trash-o btn-icon danger pull-right"
+                data-request="onDelete"
+                data-load-indicator="Deleting Venue..."
+                data-request-confirm="Do you really want to delete this venue?">
+        </button>
+        <span class="btn-text">
+                or <a href="<?= Backend::url('october/test/venues') ?>">Cancel</a>
+            </span>
+    </div>
+</div>
+
+<?= Form::close() ?>

--- a/models/Fragment.php
+++ b/models/Fragment.php
@@ -1,0 +1,14 @@
+<?php namespace October\Test\Models;
+use Model;
+
+class Fragment extends Model
+{
+    public $table = 'october_test_fragments';
+    public $timestamps = false;
+    public $morphTo = [
+        'attachment' => []
+    ];
+
+    public $fillable = ['field','data'];
+
+}

--- a/models/Venue.php
+++ b/models/Venue.php
@@ -1,0 +1,16 @@
+<?php namespace October\Test\Models;
+use Model;
+
+class Venue extends Model
+{
+    public $table = 'october_test_venues';
+    public $timestamps = false;
+    public $attachOne = [
+        'cafeinfo' => 'October\Test\Models\Fragment',
+        'parkinginfo' => 'October\Test\Models\Fragment',
+        'additionalinfo' => 'October\Test\Models\Fragment'
+    ];
+
+    public $fillable = ['field','data'];
+
+}

--- a/models/venue/columns.yaml
+++ b/models/venue/columns.yaml
@@ -1,0 +1,7 @@
+columns:
+    id:
+        label: ID
+        searchable: true
+    name:
+        label: Venue Name
+        searchable: true

--- a/models/venue/fields.yaml
+++ b/models/venue/fields.yaml
@@ -1,0 +1,25 @@
+fields:
+    name:
+        label: Name
+        span: auto
+        comment: The name of the venue
+tabs:
+    fields:
+        cafeinfo[data]:
+            tab: Cafe
+            label: Cafe
+            type: richeditor
+            comment: HTML 'attached' from the database
+            size: giant
+        parkinginfo[data]:
+            tab: Parking
+            label: Parking
+            type: richeditor
+            comment: HTML 'attached' from the database
+            size: giant
+        additionalinfo[data]:
+            tab: Additional Info
+            label: Additional Info
+            type: richeditor
+            comment: HTML 'attached' from the database
+            size: giant

--- a/updates/venues_and_fragments.php
+++ b/updates/venues_and_fragments.php
@@ -1,0 +1,33 @@
+<?php namespace Ocotober\Test\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class VenuesAndFragments extends Migration
+{
+    public function up()
+    {
+        Schema::create('october_test_venues', function ($table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        Schema::create('october_test_fragments', function ($table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->text('data')->nullable;
+            $table->string('attachment_id');
+            $table->string('attachment_type');
+            $table->string('field');
+            $table->integer('sort_order')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::drop('october_test_venues');
+        Schema::drop('october_test_fragments');
+
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -5,3 +5,6 @@
 1.0.3:
   - Seed tables
   - seed_tables.php
+1.1.0:
+  - Add tables for venues and fragments
+  - venues_and_fragments.php


### PR DESCRIPTION
Following on from this conversation, https://github.com/octobercms/october/issues/2306

There is a new form called Venues in the right hand side.

To test, create a new Venue with a name, enter content in each of the tabs and save.

All data should persist.

This only works after applying the patch here, https://github.com/octobercms/library/compare/develop...piersroberts:develop
