### PR TITLE
Test case for octobercms/october#2354

### DIFF
--- a/models/Comment.php
+++ b/models/Comment.php
@@ -53,5 +53,13 @@ class Comment extends Model
     {
         return $query->where('is_visible', true);
     }
-
+    
+    public function getFeelingOptions()
+    {
+        return [
+            'sad'      => 'Sad',
+            'happy'    => 'Happy',
+            'trolling' => "Just trollin' y'all",
+        ];
+    }
 }

--- a/models/comment/fields.yaml
+++ b/models/comment/fields.yaml
@@ -63,6 +63,18 @@ tabs:
             type: richeditor
             tab: Rich Editor
             commentAbove: Content inside a tab, inside a popup.
+        
+        # Will not throw any errors as it doesn't call FormField->resolveModelAttribute
+        breakdown[static_feeling]:
+            label: Overall feeling (Static)
+            type: text
+            tab: Breakdown
+        
+        # Again, will not throw any errors as it doesn't call FormField->resolveModelAttribute
+        breakdown[attributes][static_feeling]:
+            label: Overall feeling (Static) (Sub element)
+            type: text
+            tab: Breakdown
             
         # Will throw "trying to get property of non-object"
         # because $model = $model->breakdown will be run, and then because attributes isn't the last element,

--- a/models/comment/fields.yaml
+++ b/models/comment/fields.yaml
@@ -64,7 +64,22 @@ tabs:
             tab: Rich Editor
             commentAbove: Content inside a tab, inside a popup.
             
-        breakdown:
+        # Will throw "trying to get property of non-object"
+        # because $model = $model->breakdown will be run, and then because attributes isn't the last element,
+        # the cycle will run again and $model = $model->attributes will be run (When $model is just an array element (empty on initialization, will contain array on select))
+        breakdown[attributes][feeling]:
+            label: Overall feeling
+            type: checkboxlist
+            tab: Breakdown
+        
+        # Will throw "get_class() expects parameter 1 to be object, string given"
+        # because breakdown['feeling'] is returned as the $model object, when it's just an array element (empty on initialization, will contain string on select)
+        breakdown[feeling]:
+            label: Overall feeling
+            type: dropdown
+            tab: Breakdown
+            
+        breakdown[points]:
             tab: Breakdown
             type: repeater
             prompt: Add a new point summary


### PR DESCRIPTION
This is the test case for octobercms/october#2354 that demonstrates the need for type checking in Backend\Classes\FormField->resolveModelAttribute() (Called by Backend\Widgets\Form->getOptionsFromModel()) for fields that pull options from the model class.
