### PR TITLE
Test case for octobercms/october#2419

### DIFF
--- a/models/Member.php
+++ b/models/Member.php
@@ -40,4 +40,23 @@ class Member extends Model
     public $attachOne = [];
     public $attachMany = [];
 
+    /**
+     * Limit results to only records that are eligible to be parents of the provided model.
+     * Ineligible parents include: The provided model itself, models with the provided model 
+     * as it's own parent already, and a model that is already the current model's parent
+     *
+     * @param Query $query
+     * @param Model $model The model to check for eligible parents against
+     * @return Query
+     */
+    public function scopeEligibleParents($query, $model)
+    {
+        return $query->where('id', '!=', $model->id)
+                ->where('id', '!=', $model->parent_id)
+                ->where(function($query) use ($model) {
+                    $query->where('parent_id', '!=', $model->id)
+                        ->orWhereNull('parent_id');
+                    }
+                );
+    }
 }

--- a/models/member/fields.yaml
+++ b/models/member/fields.yaml
@@ -7,6 +7,12 @@ fields:
         label: Name
 
     parent:
-        label: Parent
-        type: relation
+        label: Parent (RecordFinder)
+        comment: Record finder field.
+        type: recordfinder
+        list: ~/plugins/october/test/models/member/columns.yaml
+        title: Please pick a parent member
+        prompt: Click the %s to find a parent member
+        nameFrom: name
+        scope: eligibleParents
 


### PR DESCRIPTION
This is the test case for octobercms/october#2419 that demonstrates the use case of passing the current model from the recordfinder formwidget to the scope applied to it.
