### PR TITLE
demonstrating routes test errors and bugs, so you can help me reproduce

### DIFF
--- a/http/controllers/UsersController.php
+++ b/http/controllers/UsersController.php
@@ -1,0 +1,14 @@
+<?php namespace October\Test\Http\Controllers;
+
+
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\Route;
+
+
+class UsersController extends Controller
+{
+	public function index(Route $route){
+		return [['username' => 'test'],['username' => 'otheruser']];
+	}
+}
+?>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="../../../tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Plugin Unit Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/routes.php
+++ b/routes.php
@@ -1,0 +1,2 @@
+<?php
+Route::get('/api/users', 'October\Test\Http\Controllers\UsersController@index');

--- a/test
+++ b/test
@@ -1,0 +1,3 @@
+# this script is to run you php tests and save some typing
+# simply run 'bash test' in plugin directory
+../../../vendor/bin/phpunit ./tests

--- a/tests/functional/RestApiTest.php
+++ b/tests/functional/RestApiTest.php
@@ -1,0 +1,39 @@
+<?php namespace October\Test\Tests\Functional;
+
+use PluginTestCase;
+use Illuminate\Support\Facades\Log;
+use October\Rain\Support\Facades\Config;
+
+class RestApiTest extends PluginTestCase
+{
+    /*
+     * I use valet for my plugins and this is the
+     * plugin development project. feel free to
+     * change this to whatever your route is. 
+     */
+    protected $baseUrl = 'http://testsuite.dev';
+
+
+    /** @test */
+    public function users_api_can_return_ok_response(){
+        $this->call('GET','/api/users');
+        $this->assertResponseOk();
+    }
+
+    /** @test */
+    public function try_to_hit_action_route(){
+        $response = $this->action(
+            'GET',
+            'October\Test\Http\Controllers\UsersController@index',
+            [],
+            []
+        );
+        $response_json = json_decode($response->getContent(), true);
+        $this->assertTrue((bool)$response_json);
+    }
+    /** @test */
+    public function can_hit_page_from_theme(){
+        $this->visit('/')
+            ->see('demo');
+    }
+}


### PR DESCRIPTION
So I am trying to run simple route tests from within my plugins. When attempting to test my API I realized I also could not test other types of routes within my project. This pull request is to give you the very basic setup I have in my plugins.

The current errors I am getting are below.
```text
1) October\Test\Tests\Functional\RestApiTest::try_to_hit_action_route
InvalidArgumentException: Action October\Test\Http\Controllers\UsersController@index not defined.

/Users/ebaird/Sites/testsuite/vendor/laravel/framework/src/Illuminate/Routing/UrlGenerator.php:589
/Users/ebaird/Sites/testsuite/vendor/laravel/framework/src/Illuminate/Foundation/Testing/CrawlerTrait.php:435
/Users/ebaird/Sites/testsuite/plugins/october/test/tests/functional/RestApiTest.php:29

--

There were 2 failures:

1) October\Test\Tests\Functional\RestApiTest::users_api_can_return_ok_response
Expected status code 200, got 404.
Failed asserting that false is true.

/Users/ebaird/Sites/testsuite/vendor/laravel/framework/src/Illuminate/Foundation/Testing/AssertionsTrait.php:19
/Users/ebaird/Sites/testsuite/plugins/october/test/tests/functional/RestApiTest.php:20

2) October\Test\Tests\Functional\RestApiTest::can_hit_page_from_theme
A request to [http://testsuite.dev] failed. Received status code [500].
```

Let me know if there is anything else I can do to help explain the problem, or if I am missing something obvious and stupid.

On a side note, I think it would be nice for your test plugin to have an internal `phpunit` setup example. Showing how you would test routes, controller, components, and more. It would be even more amazing if you were to show us how to set up test fixtures inside our plugins so that they are completely isolated from the project so we could test components in example pages.