### PR TITLE
Add checkboxlist trigger test for octobercms/october#2861

### DIFF
--- a/models/country/fields.yaml
+++ b/models/country/fields.yaml
@@ -54,6 +54,14 @@ tabs:
         pages:
             tab: Pages
             type: checkboxlist
+            
+        page_404:
+            tab: Pages
+            commentAbove: This field is enabled when the 404 page is selected
+            trigger:
+                field: pages
+                condition: value[404]
+                action: enable
 
         states:
             tab: States


### PR DESCRIPTION
Verifying octobercms/october#2861:

1. Go to Playground > Countries
2. Edit a country record or create a new one
3. Go to Pages tab
4. Select 404 page from checkbox list

The trigger on the field below the list will never fire because it gets the wrong name for the checkboxlist trigger field.  The JS is capable of dealing with the list, which can be verified by setting the trigger attributes directly with the correct name:

```
...

    page_404:
        tab: Pages
        attributes:
            data-trigger: '[name="Country[pages][]"]'
            data-trigger-condition: value[404]
            data-trigger-action: enable
...
```