### PR TITLE
Translation bug replication: rainlab/translate-plugin/issues/303

### DIFF
--- a/controllers/Records.php
+++ b/controllers/Records.php
@@ -1,0 +1,23 @@
+<?php namespace October\Test\Controllers;
+
+use Backend\Classes\Controller;
+use BackendMenu;
+
+class Records extends Controller
+{
+    public $implement = ['Backend\Behaviors\ListController','Backend\Behaviors\FormController'];
+
+    public $listConfig = 'config_list.yaml';
+    public $formConfig = 'config_form.yaml';
+
+    public $requiredPermissions = [
+
+    ];
+
+    public function __construct()
+    {
+        parent::__construct();
+        BackendMenu::setContext('October.Test', 'test', 'records');
+    }
+
+}

--- a/controllers/records/_list_toolbar.htm
+++ b/controllers/records/_list_toolbar.htm
@@ -1,0 +1,18 @@
+<div data-control="toolbar">
+        <a href="<?= Backend::url('october/test/records/create') ?>" class="btn btn-primary oc-icon-plus"><?= e(trans('backend::lang.form.create')) ?></a>
+        <button
+        class="btn btn-default oc-icon-trash-o"
+        disabled="disabled"
+        onclick="$(this).data('request-data', {
+            checked: $('.control-list').listWidget('getChecked')
+        })"
+        data-request="onDelete"
+        data-request-confirm="<?= e(trans('backend::lang.list.delete_selected_confirm')) ?>"
+        data-trigger-action="enable"
+        data-trigger=".control-list input[type=checkbox]"
+        data-trigger-condition="checked"
+        data-request-success="$(this).prop('disabled', true)"
+        data-stripe-load-indicator>
+        <?= e(trans('backend::lang.list.delete_selected')) ?>
+    </button>
+</div>

--- a/controllers/records/config_form.yaml
+++ b/controllers/records/config_form.yaml
@@ -1,0 +1,11 @@
+name: Records
+modelClass: October\Test\Models\Record
+form: $/october/test/models/record/fields.yaml
+defaultRedirect: october/test/records
+create:
+    redirect: 'october/test/records/update/:id'
+    redirectClose: october/test/records
+update:
+    redirect: october/test/records
+    redirectClose: october/test/records
+preview: {  }

--- a/controllers/records/config_list.yaml
+++ b/controllers/records/config_list.yaml
@@ -1,0 +1,11 @@
+title: Records
+modelClass: October\Test\Models\Record
+list: $/october/test/models/record/columns.yaml
+recordUrl: 'october/test/records/update/:id'
+noRecordsMessage: 'backend::lang.list.no_records'
+showSetup: true
+showCheckboxes: true
+toolbar:
+    buttons: list_toolbar
+    search:
+        prompt: 'backend::lang.list.search_prompt'

--- a/controllers/records/create.htm
+++ b/controllers/records/create.htm
@@ -1,0 +1,46 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('october/test/records') ?>">Records</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-primary">
+                    <?= e(trans('backend::lang.form.create')) ?>
+                </button>
+                <button 
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-default">
+                    <?= e(trans('backend::lang.form.create_and_close')) ?>
+                </button>
+                <span class="btn-text">
+                    <?= e(trans('backend::lang.form.or')) ?> <a href="<?= Backend::url('october/test/records') ?>"><?= e(trans('backend::lang.form.cancel')) ?></a>
+                </span>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+    <p class="flash-message static error"><?= e(trans($this->fatalError)) ?></p>
+    <p><a href="<?= Backend::url('october/test/records') ?>" class="btn btn-default"><?= e(trans('backend::lang.form.return_to_list')) ?></a></p>
+<?php endif ?>

--- a/controllers/records/index.htm
+++ b/controllers/records/index.htm
@@ -1,0 +1,1 @@
+<?= $this->listRender() ?>

--- a/controllers/records/preview.htm
+++ b/controllers/records/preview.htm
@@ -1,0 +1,22 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url(october/test/records') ?>">Records</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <div class="form-preview">
+        <?= $this->formRenderPreview() ?>
+    </div>
+
+<?php else: ?>
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+<?php endif ?>
+
+<p>
+    <a href="<?= Backend::url('october/test/records') ?>" class="btn btn-default oc-icon-chevron-left">
+        <?= e(trans('backend::lang.form.return_to_list')) ?>
+    </a>
+</p>

--- a/controllers/records/update.htm
+++ b/controllers/records/update.htm
@@ -1,0 +1,54 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('october/test/records') ?>">Records</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-request-data="redirect:0"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-primary">
+                    <?= e(trans('backend::lang.form.save')) ?>
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-default">
+                    <?= e(trans('backend::lang.form.save_and_close')) ?>
+                </button>
+                <button
+                    type="button"
+                    class="oc-icon-trash-o btn-icon danger pull-right"
+                    data-request="onDelete"
+                    data-load-indicator="<?= e(trans('backend::lang.form.deleting')) ?>"
+                    data-request-confirm="<?= e(trans('backend::lang.form.confirm_delete')) ?>">
+                </button>
+
+                <span class="btn-text">
+                    <?= e(trans('backend::lang.form.or')) ?> <a href="<?= Backend::url('october/test/records') ?>"><?= e(trans('backend::lang.form.cancel')) ?></a>
+                </span>
+            </div>
+        </div>
+    <?= Form::close() ?>
+
+<?php else: ?>
+    <p class="flash-message static error"><?= e(trans($this->fatalError)) ?></p>
+    <p><a href="<?= Backend::url('october/test/records') ?>" class="btn btn-default"><?= e(trans('backend::lang.form.return_to_list')) ?></a></p>
+<?php endif ?>

--- a/models/Record.php
+++ b/models/Record.php
@@ -1,0 +1,36 @@
+<?php namespace October\Test\Models;
+
+use Model;
+
+/**
+ * Model
+ */
+class Record extends Model
+{
+    use \October\Rain\Database\Traits\Validation;
+    
+    /*
+     * Disable timestamps by default.
+     * Remove this line if timestamps are defined in the database table.
+     */
+    public $timestamps = false;
+
+    /*
+     * Validation
+     */
+    public $rules = [
+    ];
+
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'october_test_records';
+
+    public $implement = ['RainLab.Translate.Behaviors.TranslatableModel'];
+
+    public $translatable = ['title', 'fields_in_json[test1]', 'fields_in_json[test2]'];
+
+    protected $casts = [
+        'fields_in_json' => 'array'
+    ];
+}

--- a/models/record/columns.yaml
+++ b/models/record/columns.yaml
@@ -1,0 +1,11 @@
+columns:
+    id:
+        label: '#'
+        type: number
+        searchable: true
+        sortable: true
+    title:
+        label: Title
+        type: text
+        searchable: true
+        sortable: true

--- a/models/record/fields.yaml
+++ b/models/record/fields.yaml
@@ -1,0 +1,16 @@
+fields:
+    title:
+        label: Title
+        oc.commentPosition: ''
+        span: full
+        type: text
+    'fields_in_json[test1]':
+        label: Test1
+        oc.commentPosition: ''
+        span: auto
+        type: text
+    'fields_in_json[test2]':
+        label: Test2
+        oc.commentPosition: ''
+        span: auto
+        type: text

--- a/updates/builder_table_create_october_test_records.php
+++ b/updates/builder_table_create_october_test_records.php
@@ -1,0 +1,23 @@
+<?php namespace October\Test\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class BuilderTableCreateOctoberTestRecords extends Migration
+{
+    public function up()
+    {
+        Schema::create('october_test_records', function($table)
+        {
+            $table->engine = 'InnoDB';
+            $table->increments('id')->unsigned();
+            $table->string('title');
+            $table->text('fields_in_json');
+        });
+    }
+    
+    public function down()
+    {
+        Schema::dropIfExists('october_test_records');
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,7 +1,10 @@
-1.0.1: First version of Test
+1.0.1: 'First version of Test'
 1.0.2:
-  - Create tables
-  - create_tables.php
+    - 'Create tables'
+    - create_tables.php
 1.0.3:
-  - Seed tables
-  - seed_tables.php
+    - 'Seed tables'
+    - seed_tables.php
+1.0.4:
+    - 'Created table october_test_records'
+    - builder_table_create_october_test_records.php


### PR DESCRIPTION
https://github.com/rainlab/translate-plugin/issues/303

1. Install RainLab.Traqnslation plugin and add any second language in the settings
2. Make sure that migration plugins/october/test/updates/builder_table_create_october_test_records.php is in DB
3. Go to yor_domain.dev/backend/october/test/records
4. Create new record and fill all fields for every translation
5. Go back to list of records an edit records from previous step
6. Try to switch translation for Test1 and Test2 fields. When you switch back to default translation you will see empty field.