### PR TITLE
Demonstrate proxy fields issue with BelongsTo relation

### DIFF
--- a/controllers/Posts.php
+++ b/controllers/Posts.php
@@ -2,6 +2,7 @@
 
 use BackendMenu;
 use Backend\Classes\Controller;
+use October\Test\Models\Attribute;
 
 /**
  * Posts [and Comments] Back-end Controller
@@ -41,6 +42,18 @@ class Posts extends Controller
     {
         $this->asExtension('ListController')->index();
         $this->bodyClass = 'compact-container';
+    }
+
+    public function formExtendModel($model)
+    {
+        /*
+         * Init proxy field model if we are creating the model
+         */
+        if ($this->action == 'create') {
+            $model->status = new Attribute();
+        }
+
+        return $model;
     }
 
     //

--- a/models/post/fields.yaml
+++ b/models/post/fields.yaml
@@ -61,6 +61,20 @@ tabs:
             type: partial
             tab: Reviews
 
+        status[name]:
+            label: Name
+            commentAbove: Use proxy fields to create a new status here
+            type: text
+            span: left
+            tab: Status
+
+        status[code]:
+            label: Code
+            commentAbove: Another proxy field for the demo purpose
+            type: text
+            span: right
+            tab: Status
+
 secondaryTabs:
     fields:
 


### PR DESCRIPTION
This demonstrates the issue mentionned here: https://github.com/octobercms/october/issues/2845#issuecomment-334259343

Steps to reproduce:

- Create new ``Post``
- Fill in a name (required)
- Switch to the ``Status`` tab and fill ``Name`` and ``Code``. Both are proxy fields to the ``status`` relation
- Click "Create"
- Carefully watch the database. Both models (``Attribute`` and ``Post``) are created, but not linked to each other.

Please note that this is not the most realisitc use case, I just tried to change as few files as possible.