### PR TITLE
Demonstration for octobercms/october#3067

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -69,6 +69,11 @@ class Plugin extends PluginBase
                         'icon'        => 'icon-database',
                         'url'         => Backend::url('october/test/trees'),
                     ],
+                    'nestedgrouprepeaters' => [
+                        'label'       => 'Nested Group Repeaters',
+                        'icon'        => 'icon-database',
+                        'url'         => Backend::url('october/test/nestedgrouprepeaters'),
+                    ],
                 ]
             ]
         ];

--- a/controllers/NestedGroupRepeaters.php
+++ b/controllers/NestedGroupRepeaters.php
@@ -1,0 +1,25 @@
+<?php namespace October\Test\Controllers;
+
+use BackendMenu;
+use Backend\Classes\Controller;
+
+/**
+ * Nested Group Repeaters Back-end Controller
+ */
+class NestedGroupRepeaters extends Controller
+{
+    public $implement = [
+        'Backend.Behaviors.FormController',
+        'Backend.Behaviors.ListController'
+    ];
+
+    public $formConfig = 'config_form.yaml';
+    public $listConfig = 'config_list.yaml';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        BackendMenu::setContext('October.Test', 'test', 'nestedgrouprepeaters');
+    }
+}

--- a/controllers/nestedgrouprepeaters/_list_toolbar.htm
+++ b/controllers/nestedgrouprepeaters/_list_toolbar.htm
@@ -1,0 +1,21 @@
+<div data-control="toolbar">
+    <a
+        href="<?= Backend::url('october/test/nestedgrouprepeaters/create') ?>"
+        class="btn btn-primary oc-icon-plus">
+        New Nested Group Repeater
+    </a>
+
+    <button
+        class="btn btn-danger oc-icon-trash-o"
+        disabled="disabled"
+        onclick="$(this).data('request-data', { checked: $('.control-list').listWidget('getChecked') })"
+        data-request="onDelete"
+        data-request-confirm="Are you sure you want to delete the selected Nested Group Repeaters?"
+        data-trigger-action="enable"
+        data-trigger=".control-list input[type=checkbox]"
+        data-trigger-condition="checked"
+        data-request-success="$(this).prop('disabled', 'disabled')"
+        data-stripe-load-indicator>
+        Delete selected
+    </button>
+</div>

--- a/controllers/nestedgrouprepeaters/config_form.yaml
+++ b/controllers/nestedgrouprepeaters/config_form.yaml
@@ -1,0 +1,31 @@
+# ===================================
+#  Form Behavior Config
+# ===================================
+
+# Record name
+name: Nested Group Repeater
+
+# Model Form Field configuration
+form: $/october/test/models/nestedgrouprepeater/fields.yaml
+
+# Model Class name
+modelClass: October\Test\Models\NestedGroupRepeater
+
+# Default redirect location
+defaultRedirect: october/test/nestedgrouprepeaters
+
+# Create page
+create:
+    title: Create Nested Group Repeater
+    redirect: october/test/nestedgrouprepeaters/update/:id
+    redirectClose: october/test/nestedgrouprepeaters
+
+# Update page
+update:
+    title: Edit Nested Group Repeater
+    redirect: october/test/nestedgrouprepeaters
+    redirectClose: october/test/nestedgrouprepeaters
+
+# Preview page
+preview:
+    title: Preview Nested Group Repeater

--- a/controllers/nestedgrouprepeaters/config_list.yaml
+++ b/controllers/nestedgrouprepeaters/config_list.yaml
@@ -1,0 +1,47 @@
+# ===================================
+#  List Behavior Config
+# ===================================
+
+# Model List Column configuration
+list: $/october/test/models/nestedgrouprepeater/columns.yaml
+
+# Model Class name
+modelClass: October\Test\Models\NestedGroupRepeater
+
+# List Title
+title: Manage Nested Group Repeaters
+
+# Link URL for each record
+recordUrl: october/test/nestedgrouprepeaters/update/:id
+
+# Message to display if the list is empty
+noRecordsMessage: backend::lang.list.no_records
+
+# Records to display per page
+recordsPerPage: 20
+
+# Display page numbers with pagination, disable to improve performance
+showPageNumbers: true
+
+# Displays the list column set up button
+showSetup: true
+
+# Displays the sorting link on each column
+showSorting: true
+
+# Default sorting column
+# defaultSort:
+#     column: created_at
+#     direction: desc
+
+# Display checkboxes next to each record
+showCheckboxes: true
+
+# Toolbar widget configuration
+toolbar:
+    # Partial for toolbar buttons
+    buttons: list_toolbar
+
+    # Search widget configuration
+    search:
+        prompt: backend::lang.list.search_prompt

--- a/controllers/nestedgrouprepeaters/create.htm
+++ b/controllers/nestedgrouprepeaters/create.htm
@@ -1,0 +1,48 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('october/test/nestedgrouprepeaters') ?>">Nested Group Repeaters</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="Creating NestedGroupRepeater..."
+                    class="btn btn-primary">
+                    Create
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="Creating NestedGroupRepeater..."
+                    class="btn btn-default">
+                    Create and Close
+                </button>
+                <span class="btn-text">
+                    or <a href="<?= Backend::url('october/test/nestedgrouprepeaters') ?>">Cancel</a>
+                </span>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('october/test/nestedgrouprepeaters') ?>" class="btn btn-default">Return to nested group repeaters list</a></p>
+
+<?php endif ?>

--- a/controllers/nestedgrouprepeaters/index.htm
+++ b/controllers/nestedgrouprepeaters/index.htm
@@ -1,0 +1,2 @@
+
+<?= $this->listRender() ?>

--- a/controllers/nestedgrouprepeaters/preview.htm
+++ b/controllers/nestedgrouprepeaters/preview.htm
@@ -1,0 +1,19 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('october/test/nestedgrouprepeaters') ?>">Nested Group Repeaters</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <div class="form-preview">
+        <?= $this->formRenderPreview() ?>
+    </div>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('october/test/nestedgrouprepeaters') ?>" class="btn btn-default">Return to nested group repeaters list</a></p>
+
+<?php endif ?>

--- a/controllers/nestedgrouprepeaters/update.htm
+++ b/controllers/nestedgrouprepeaters/update.htm
@@ -1,0 +1,56 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('october/test/nestedgrouprepeaters') ?>">Nested Group Repeaters</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-request-data="redirect:0"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="Saving NestedGroupRepeater..."
+                    class="btn btn-primary">
+                    <u>S</u>ave
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="Saving NestedGroupRepeater..."
+                    class="btn btn-default">
+                    Save and Close
+                </button>
+                <button
+                    type="button"
+                    class="oc-icon-trash-o btn-icon danger pull-right"
+                    data-request="onDelete"
+                    data-load-indicator="Deleting NestedGroupRepeater..."
+                    data-request-confirm="Delete this nestedgrouprepeater?">
+                </button>
+                <span class="btn-text">
+                    or <a href="<?= Backend::url('october/test/nestedgrouprepeaters') ?>">Cancel</a>
+                </span>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('october/test/nestedgrouprepeaters') ?>" class="btn btn-default">Return to nested group repeaters list</a></p>
+
+<?php endif ?>

--- a/models/NestedGroupRepeater.php
+++ b/models/NestedGroupRepeater.php
@@ -1,0 +1,38 @@
+<?php namespace October\Test\Models;
+
+use Model;
+
+/**
+ * NestedGroupRepeater Model
+ */
+class NestedGroupRepeater extends Model
+{
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'october_test_nested_group_repeaters';
+
+    /**
+     * @var array Guarded fields
+     */
+    protected $guarded = ['*'];
+
+    /**
+     * @var array Fillable fields
+     */
+    protected $fillable = [];
+    protected $jsonable = ['repeater_data', 'group_repeater_data'];
+
+    /**
+     * @var array Relations
+     */
+    public $hasOne = [];
+    public $hasMany = [];
+    public $belongsTo = [];
+    public $belongsToMany = [];
+    public $morphTo = [];
+    public $morphOne = [];
+    public $morphMany = [];
+    public $attachOne = [];
+    public $attachMany = [];
+}

--- a/models/nestedgrouprepeater/columns.yaml
+++ b/models/nestedgrouprepeater/columns.yaml
@@ -1,0 +1,8 @@
+# ===================================
+#  List Column Definitions
+# ===================================
+
+columns:
+    id:
+        label: ID
+        searchable: true

--- a/models/nestedgrouprepeater/fields.yaml
+++ b/models/nestedgrouprepeater/fields.yaml
@@ -1,0 +1,35 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+    repeater_data:
+        label: Repeater 1
+        type: repeater
+        form:
+            fields:
+                group_repeater_1:
+                    label: Group Repeater 1
+                    type: repeater
+                    groups:
+                        group1:
+                            name: Group1
+                            fields:
+                                value:
+                                    label: Value
+    group_repeater_data:
+        label: Group Repeater 2
+        type: repeater
+        groups:
+            group2:
+                name: Group 2
+                fields:
+                    group_repeater_3:
+                        label: Group Repeater 3
+                        type: repeater
+                        groups:
+                            group3:
+                                name: Group 3
+                                fields:
+                                    value:
+                                        label: Value

--- a/updates/create_nested_group_repeaters_table.php
+++ b/updates/create_nested_group_repeaters_table.php
@@ -1,0 +1,24 @@
+<?php namespace October\Test\Updates;
+
+use Schema;
+use October\Rain\Database\Schema\Blueprint;
+use October\Rain\Database\Updates\Migration;
+
+class CreateNestedGroupRepeatersTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('october_test_nested_group_repeaters', function(Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->json('repeater_data')->nullable();
+            $table->json('group_repeater_data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('october_test_nested_group_repeaters');
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -5,3 +5,6 @@
 1.0.3:
   - Seed tables
   - seed_tables.php
+1.0.4:
+  - Create Nested Group Repeater Table
+  - create_nested_group_repeaters_table.php


### PR DESCRIPTION
PR demonstrating the issue reported in octobercms/october#3067

## Repro

**1. Create a new record under "Nested Group Repeaters"**

![empty](https://user-images.githubusercontent.com/7088166/39089106-62ba53c8-4574-11e8-93a4-4c4ad217069a.png)

**2. Add test data per the attached screenshot. This demonstrates a group repeater nested in a normal repeater and a group repeater nested in a group repeater**

![with-data](https://user-images.githubusercontent.com/7088166/39089111-892d9100-4574-11e8-844f-c3ce1b4db1d5.png)

**3. Save and refresh**

## Expected Behavior

After saving test data and refreshing, the form should look like it did before refreshing the page

![with-data](https://user-images.githubusercontent.com/7088166/39089111-892d9100-4574-11e8-844f-c3ce1b4db1d5.png)

## Actual Behavior

Nested group repeaters are populated, but empty

![after-save-and-refresh](https://user-images.githubusercontent.com/7088166/39089113-948ec370-4574-11e8-8757-04e2b760cddd.png)

## Cause of Issue

The issue is because the data that is saved to the database is missing the `_group` field. So when it's time to render the nested group repeaters, we don't know which group is supposed to be rendered, so nothing is rendered.

**Actual saved JSON from above example**

**1. repeater_data**

```json
[
    {
        "group_repeater_1": {
            "1": {
                "value": "Test"
            }
        }
    }
]
```

**2. group_repeater_data**

```json
[
    {
        "_group": "group2",
        "group_repeater_3": {
            "1": {
                "value": "Test"
            }
        }
    }
]
```

If I manually change the JSON values to match the following. It will work as expected and render the nested group repeaters successfully.

**Modified JSON values**

**1. repeater_data**

```json
[
    {
        "group_repeater_1": [
            {
                "value": "Test",
                "_group": "group1"
            }
        ]
    }
]
```

**2. group_repeater_data**

```json
[
    {
        "_group": "group2",
        "group_repeater_3": [
            {
                "value": "Test",
                "_group": "group3"
            }
        ]
    }
]
```

As to why the `_group` field isn't being saved, throwing some traceLogs in `/modules/backend/formwidgets/Repeater.php` seems to indicate that the nested group repeaters aren't running their `processSaveValue` method on save.

I didn't dig deep enough to conclusively determine why the nested group repeaters aren't running their `processSaveValue` method, but it appears as though they're not being instantiated properly (or at all) because their data is being processed by the top level repeater as part of the top level repeater's data.