### PR TITLE
Add trigger tests for multiple field values

### DIFF
--- a/models/country/fields.yaml
+++ b/models/country/fields.yaml
@@ -55,13 +55,21 @@ tabs:
             tab: Pages
             type: checkboxlist
 
-        page_404:
+        _page_404:
             tab: Pages
             commentAbove: This field is enabled when the 404 page is selected
             trigger:
                 field: pages[]
                 condition: value[404]
                 action: enable
+
+        _page_error:
+            tab: Pages
+            commentAbove: This field is hidden when the error page is selected
+            trigger:
+                field: pages[]
+                condition: value[error]
+                action: hide
 
         states:
             tab: States

--- a/models/post/fields.yaml
+++ b/models/post/fields.yaml
@@ -72,6 +72,14 @@ tabs:
             nameFrom: name
             tab: Tags
 
+        _tags_trigger:
+            commentAbove: Hide if "a" or "b" are used as tags above
+            tab: Tags
+            trigger:
+                action: hide
+                field: tags[]
+                condition: value[a][b]
+
         tags_array:
             label: Tags saved as Array
             type: taglist


### PR DESCRIPTION
It turns out that the test I submitted for #41 misses some related issues. The fix in octobercms/october@2164c0761623ac0dcd8e4c216a27e0ca17f2d23b takes care of the trigger field name issue, but the JS actually doesn't properly handle field types with multiple selected values. The test in #41 passes only because the trigger is on the `404` page selection, which is always the first option and thus the result of `$.val()` if selected.

I've added a trigger test to the Tags tab on the post form to show that a value check against a `taglist` does not work (`$.val()` returns an array), and I've added another check to the Pages tab on the country form. If only the `error` page is selected, its corresponding trigger will work, but if `404` or `ajax` are selected, since they come before it in the list, the `error` page trigger will not fire.

I will submit a PR with a fix shortly.