### PR TITLE
Add tests for nested Repeater/MLRepeater usage

### DIFF
--- a/config/repeater_fields.yaml
+++ b/config/repeater_fields.yaml
@@ -2,6 +2,19 @@
 #  Used by Grouped Repeater
 # ===================================
 
+recurse:
+    name: Recurse
+    description: Repeater recursion
+    icon: icon-refresh
+    fields:
+        children:
+            label: Content
+            prompt: Add content block
+            span: full
+            type: repeater
+
+            groups: $/october/test/config/repeater_fields.yaml
+
 textarea:
     name: Textarea
     description: Basic text field
@@ -51,3 +64,13 @@ image:
                 left: Left
                 center: Center
                 right: Right
+
+taglist:
+    name: Tag list
+    description: Tag list in string mode
+    icon: icon-tags
+    fields:
+        tags:
+            label: Tag list
+            type: taglist
+            mode: string

--- a/models/Country.php
+++ b/models/Country.php
@@ -40,6 +40,13 @@ class Country extends Model
         ],
     ];
 
+    /**
+     * Softly implement the TranslatableModel behavior.
+     */
+    public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
+
+    public $translatable = ['states', 'content'];
+
     public function filterFields($fields, $context = null)
     {
         // Repeater field shares this logic


### PR DESCRIPTION
This shows a couple of issues with repeaters that should be addressed by octobercms/october#3729 and rainlab/translate-plugin#409.

A couple of repeater groups have been added to `Countries > Content`. The one named `Recurse` allows for arbitrary levels of nesting. Currently, two levels of nesting can be added, but attempts to save the form throw an error. Attempting to add another level of nesting will similarly fail.

The `Tag list` group adds a `taglist` widget in string mode. Because repeaters are currently returning the raw form data via `getSaveValue`, a child `taglist` will never have a chance to process the save data. After adding tags to a `taglist` and saving, an exception will be thrown on reloading the page, as the saved value is the raw array rather than the expected string.

Both `Countries > Content` and `Countries > States` conditionally support RainLab.Translate so that MLRepeater functionality can also be verified with group and non-group usage.