### PR TITLE
example of output functions not working #4368

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -188,4 +188,11 @@ class Plugin extends PluginBase
             }
         }
     }
+
+    public function registerComponents()
+    {
+        return [
+            Components\TestComponents::class => 'TestComponent'
+        ];
+    }
 }

--- a/components/TestComponents.php
+++ b/components/TestComponents.php
@@ -1,0 +1,29 @@
+<?php namespace October\Test\Components;
+
+use Cms\Classes\ComponentBase;
+
+class TestComponents extends ComponentBase
+{
+    public function componentDetails()
+    {
+        return [
+            'name'        => 'TestComponents Component',
+            'description' => 'No description provided yet...',
+        ];
+    }
+
+    public function defineProperties()
+    {
+        return [];
+    }
+
+    public function test()
+    {
+        // this code will not work either
+
+        // echo 'this text should appear';
+        // die();
+
+        dd('If a new version of twig (≥ 2.10.0) is installed, it will give out 500 error');
+    }
+}


### PR DESCRIPTION
to reproduce the error, in `themes/demo/layout/default.htm` add the `[TestComponent]` component and call in code the method `{{ TestComponent.test() }}`

output functions from twig version (≥ 2.10.0) do not work

should produce information with debug data, but in the case of the `dd()` function, this is 500 error, and in the case of `echo`, `print_r()` is an empty answer