### PR TITLE
add select with ajax options to person form

### DIFF
--- a/controllers/People.php
+++ b/controllers/People.php
@@ -40,4 +40,15 @@ class People extends Controller
 
         return $model;
     }
+
+    public function onGetOptions()
+    {
+        $results = [
+            'key' => 'value',
+            'foo' => 'bar',
+            'baz' => 'baz'
+        ];
+
+        return ['result' => $results];
+    }
 }

--- a/controllers/people/_ajax_options.htm
+++ b/controllers/people/_ajax_options.htm
@@ -1,0 +1,7 @@
+<select
+    class="form-control custom-select"
+    data-handler="onGetOptions"
+    data-minimum-input-length="2"
+    data-ajax--delay="300"
+    data-request-data="foo: 'bar'"
+    ></select>

--- a/models/person/fields.yaml
+++ b/models/person/fields.yaml
@@ -23,6 +23,11 @@ fields:
         options:
             '0': No
             '1': Yes
+    
+    ajax_options:
+        label: AJAX Options
+        comment: These options should be populated using AJAX
+        type: partial
 
     # Record Finder (Default)
     phone:


### PR DESCRIPTION
This PR implements the example provided by October's docs for select fields. 

1. Navigate to the People controller
2. Verify the AJAX Options field is present below the Married field
3. Try to search for a value
4. Notice no options are returned

See [https://octobercms.com/docs/ui/select](https://octobercms.com/docs/ui/select) for more information.

