### PR TITLE
Add create button to user role pivot relationship

### DIFF
--- a/controllers/users/config_relation.yaml
+++ b/controllers/users/config_relation.yaml
@@ -15,6 +15,7 @@ roles_pivot:
     label: Role
     view:
         list: ~/plugins/october/test/models/userrolepivot/columns.yaml
+        toolbarButtons: add|remove|create
         showSearch: true
     manage:
         list: ~/plugins/october/test/models/role/columns.yaml
@@ -25,6 +26,7 @@ roles_pivot_model:
     label: Role
     view:
         list: ~/plugins/october/test/models/userrolepivot/columns.yaml
+        toolbarButtons: add|remove|create
         showSearch: true
     manage:
         list: ~/plugins/october/test/models/role/columns.yaml


### PR DESCRIPTION
There seems to be an issue when trying to create new records with pivot data using the relation behavior. This PR adds a create button to the User/Roll relation config definition. When clicking the `create` button an error is throw `Call to member function getId() on null`.