### PR TITLE
Search demonstration on Channels

### DIFF
--- a/controllers/Trees.php
+++ b/controllers/Trees.php
@@ -1,29 +1,39 @@
 <?php namespace October\Test\Controllers;
 
-use BackendMenu;
 use Backend\Classes\Controller;
+use BackendMenu;
+use October\Test\Models\Channel;
 
 /**
  * Trees Back-end Controller
  */
 class Trees extends Controller
 {
-    public $implement = [
-        'Backend.Behaviors.ListController'
-    ];
-
-    public $listConfig = [
-        'members' => 'config_members_list.yaml',
-        'categories' => 'config_categories_list.yaml',
-        'channels' => 'config_channels_list.yaml'
-    ];
-
-    public $requiredPermissions = ['october.test.access_plugin'];
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        BackendMenu::setContext('October.Test', 'test', 'trees');
-    }
+	public $implement = [
+		'Backend.Behaviors.ListController'
+	];
+	
+	public $listConfig = [
+		'members'    => 'config_members_list.yaml',
+		'categories' => 'config_categories_list.yaml',
+		'channels'   => 'config_channels_list.yaml'
+	];
+	
+	public $requiredPermissions = ['october.test.access_plugin'];
+	
+	public function __construct()
+	{
+		parent::__construct();
+		
+		BackendMenu::setContext('October.Test', 'test', 'trees');
+	}
+	
+	public function listExtendRecords($records, $definition)
+	{
+		if ( $definition === 'channels' ) {
+			return Channel::whereIn('id', [11, 12])->get()->toNested(false);
+		}
+		
+		return $records;
+	}
 }

--- a/controllers/trees/config_channels_list.yaml
+++ b/controllers/trees/config_channels_list.yaml
@@ -25,7 +25,7 @@ showSetup: true
 
 # Show tree
 showTree: true
-treeExpanded: true
+treeExpanded: false
 
 # Toolbar widget configuration
 toolbar:

--- a/updates/seeder104.php
+++ b/updates/seeder104.php
@@ -1,0 +1,15 @@
+<?php namespace October\Test\Updates;
+
+use Illuminate\Support\Str;
+use October\Rain\Database\Updates\Seeder;
+use October\Test\Models\Channel;
+
+class Seeder104 extends Seeder
+{
+	public function run(): void
+	{
+		$parent = Channel::create(['title' => 'PARENT', 'description' => Str::random(30)]);
+		$parent2 = Channel::create(['title' => 'PARENT_TWO', 'description' => Str::random(30), 'parent_id' => $parent->id]);
+		Channel::create(['title' => 'CHILD_SEARCH', 'parent_id' => $parent2->id]);
+	}
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -5,3 +5,6 @@
 1.0.3:
     - 'Seed tables'
     - seed_tables.php
+1.0.4:
+    - 'Seed test data'
+    - seeder104.php


### PR DESCRIPTION
1. Seed Seeder104.php
2. Go to - /backend/october/test/trees
3. In channels list i`m filtered nested tree begin at 1 level by listExtendRecords method - maybe I'm doing it wrong. The question is how not to break the tree when searching?
4. After input in search field CHILD_SEARCH - list empty
5. After clear text from search input , nested tree in list not recover

1. In /backend/october/test/trees
2. Search category
3. Tree break
4. clear search input
5. tree not recovered

I understand that to display a large number of records it is better not to use the tree at all.
I would like the tree to be restored after the search, because when the tree is collapsed. After the search, it unfolds. And this is a problem when the number of records is more than 500 for example.
It’s convenient to work with a large tree using the search = (
