### PR TITLE
Force save to bypass photo validation in seeder

### DIFF
--- a/updates/seed_tables.php
+++ b/updates/seed_tables.php
@@ -98,7 +98,7 @@ class SeedAllTables extends Seeder
 
         $user = User::first();
         $user->country()->add($country1);
-        $user->save();
+        $user->forceSave();
 
         $country2 = Country::create([
             'name' => 'Blueseed',


### PR DESCRIPTION
Hi, while testing this plugin, the migrations failed due to the phone validation on the user model. 
Added forceSave to bypass the validation.