### PR TITLE
Test Issue "Relation Behavior is not available within the model at runtime"

### DIFF
--- a/models/City.php
+++ b/models/City.php
@@ -7,6 +7,12 @@ use Model;
  */
 class City extends Model
 {
+    use October\Rain\Database\Traits\Validation;
+
+    public $rules = [
+        'country' => 'required'
+    ];
+
     /**
      * @var string The database table used by the model.
      */

--- a/models/Location.php
+++ b/models/Location.php
@@ -58,4 +58,21 @@ class Location extends Model
 
         return City::lists('name', 'id');
     }
+
+    public function filterFields($fields, $context = null)
+    {
+        //trying to get by $this->relation
+        if ($this->country?->code == 'petoria' && $context == 'refresh') {
+            $fields->city->hidden = true;
+        } else {
+            $fields->city->hidden = false;
+        }
+
+        //trying to get the value that should contain the ID of the record.
+        if ($fields->country?->value == 1 && $context == 'refresh') {
+            $fields->city->hidden = true;
+        } else {
+            $fields->city->hidden = false;
+        }
+    }
 }


### PR DESCRIPTION
### Test 1:

*Menu Playground > Locations > Manage Cities*
Try to save the city records, now the country is required, but even filling it, it will show as required.


### Test 2:

*Menu Playground > Locations*
Inside a location record, when selecting the country Petoria, the city field should hide, `filterFields()` should do that, but it doesn't.