### PR TITLE
Add a dashboard data source

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -1,8 +1,10 @@
 <?php namespace October\Test;
 
 use Backend;
+use October\Test\Classes\LocationDataSource;
 use System\Classes\PluginBase;
 use System\Classes\SettingsManager;
+use Dashboard\Classes\DashManager;
 
 /**
  * Plugin Information File
@@ -47,6 +49,9 @@ class Plugin extends PluginBase
                 'parent_id',
             ]);
         });
+
+        // Register data sources
+        $this->registerDashboardDatasources();
 
         // \Event::listen('backend.brand.getPalettePresets', function(&$presets) {
         //     unset($presets['punch']);
@@ -274,5 +279,16 @@ class Plugin extends PluginBase
     public function registerSchedule($schedule)
     {
         $schedule->command('cache:clear')->everyMinute();
+    }
+
+    /**
+     * registerDashboardDatasources
+     */
+    protected function registerDashboardDatasources()
+    {
+        DashManager::instance()->registerDataSourceClass(
+            LocationDataSource::class,
+            'Locations'
+        );
     }
 }

--- a/classes/LocationDataSource.php
+++ b/classes/LocationDataSource.php
@@ -1,0 +1,61 @@
+<?php namespace October\Test\Classes;
+
+use Dashboard\Classes\ReportMetric;
+use Dashboard\Classes\ReportDimension;
+use Dashboard\Classes\ReportDataSourceBase;
+use Dashboard\Classes\ReportFetchData;
+use Dashboard\Classes\ReportFetchDataResult;
+use Dashboard\Classes\ReportQueryBuilder;
+
+/**
+ * LocationDataSource providing information about test plugin locations.
+ */
+class LocationDataSource extends ReportDataSourceBase
+{
+    const DIMENSION_COUNTRY = 'country';
+    const DIMENSION_CITY = 'city';
+
+    const METRIC_COUNT = 'count';
+
+    /**
+     * __construct the data source
+     */
+    public function __construct()
+    {
+        $this->registerDimension(new ReportDimension(
+            self::DIMENSION_COUNTRY,
+            'october_test_countries.id',
+            'Country',
+            'october_test_countries.name'
+        ));
+
+        $this->registerDimension(new ReportDimension(
+            self::DIMENSION_CITY,
+            'october_test_cities.id',
+            'City',
+            'october_test_cities.name'
+        ));
+
+        $this->registerMetric(new ReportMetric(
+            self::METRIC_COUNT,
+            'october_test_locations.id',
+            'Location Count',
+            ReportMetric::AGGREGATE_COUNT
+        ));
+    }
+
+    /**
+     * fetchData
+     */
+    protected function fetchData(ReportFetchData $data): ReportFetchDataResult
+    {
+        $data = ReportQueryBuilder::fromFetchData($data, 'october_test_locations')
+            ->onConfigureMetrics(function($query, $dimension, $metrics) {
+                $query->leftJoin('october_test_cities', 'october_test_cities.id', '=', 'october_test_locations.city_id')
+                    ->leftJoin('october_test_countries', 'october_test_countries.id', '=', 'october_test_locations.country_id');
+            })
+            ->get($data->metricsConfiguration);
+
+        return $data;
+    }
+}

--- a/updates/seed_tables.php
+++ b/updates/seed_tables.php
@@ -197,6 +197,16 @@ class SeedAllTables extends Seeder
             ['country_id' => $country2->id, 'city_id' => 6, 'name' => '5309 Imagination Crescrent'],
             ['country_id' => $country2->id, 'city_id' => 7, 'name' => '22 2201 Seymour Drive'],
             ['country_id' => $country2->id, 'city_id' => 8, 'name' => '2322 Xray Alphabet'],
+            ['country_id' => $country1->id, 'city_id' => 1, 'name' => '123 Main St'],
+            ['country_id' => $country1->id, 'city_id' => 1, 'name' => '456 Elm Ave'],
+            ['country_id' => $country1->id, 'city_id' => 1, 'name' => '789 Oak Blvd'],
+            ['country_id' => $country1->id, 'city_id' => 2, 'name' => '321 Pine Rd'],
+            ['country_id' => $country1->id, 'city_id' => 3, 'name' => '654 Maple Ln'],
+            ['country_id' => $country1->id, 'city_id' => 3, 'name' => '987 Cedar Ct'],
+            ['country_id' => $country1->id, 'city_id' => 4, 'name' => '111 Birch Pl'],
+            ['country_id' => $country2->id, 'city_id' => 5, 'name' => '222 Spruce Way'],
+            ['country_id' => $country2->id, 'city_id' => 6, 'name' => '333 Fir Dr'],
+            ['country_id' => $country2->id, 'city_id' => 7, 'name' => '444 Willow St'],
         ]);
 
         /*


### PR DESCRIPTION
This adds a test for a [Dashboard datasource](https://docs.octobercms.com/4.x/extend/dashboards/data-sources.html#creating-data-sources)

It illustrates an issue with labels not beeing shown in case there are too many categories available in a bar chart. To reproduce the problem, add a new Bar chart with the following config:
<img width="612" height="501" alt="image" src="https://github.com/user-attachments/assets/e4d5ec59-330d-4002-a851-35f844c1ad0d" />

The rendered chart looks like this (labels for every second option are missing):
<img width="607" height="355" alt="image" src="https://github.com/user-attachments/assets/2ba4a0b0-8a32-4d89-b491-d3cfa10a9846" />
